### PR TITLE
AUI-3178 In Calendar's monthly view, when today’s date is the last week of the month, the blue border is cut out

### DIFF
--- a/src/aui-datatype/js/aui-datatype.js
+++ b/src/aui-datatype/js/aui-datatype.js
@@ -964,6 +964,31 @@ A.mix(A.DataType.DateMath, {
     },
 
     /**
+     * Returns the number of weeks in that month.
+     *
+     * @method getWeeksInMonth
+     * @param {Date} date The JavaScript date for which to find the week number
+     * @param {Number} firstDayOfWeek The index of the first day of the week (0
+     *     = Sun, 1 = Mon ... 6 = Sat). Defaults to 0
+     * @protected
+     */
+    getWeeksInMonth(date, firstDayOfWeek) {
+        var daysInMonth = this.getDaysInMonth(date.getFullYear(), date.getMonth());
+        var firstWeekDay =
+            this.getDate(date.getFullYear(), date.getMonth(), 1).getDay() - firstDayOfWeek;
+
+        if (firstWeekDay < 0) {
+            firstWeekDay = firstWeekDay + 7;
+        }
+
+        var daysInFirstWeek = this.WEEK_LENGTH - firstWeekDay;
+
+        return (
+            Math.ceil((daysInMonth - daysInFirstWeek) / this.WEEK_LENGTH) + 1
+        );
+    },
+
+    /**
      * Converts a date to US time format.
      *
      * @method toUsTimeString

--- a/src/aui-datatype/js/aui-datatype.js
+++ b/src/aui-datatype/js/aui-datatype.js
@@ -853,6 +853,26 @@ A.mix(A.DataType.DateMath, {
     },
 
     /**
+     * Determines whether a given date is the same date on the calendar.
+     *
+     * @method sameDay
+     * @param {Date} date The Date object to compare with the compare
+     *     argument
+     * @param {Date} compareTo The Date object to use for the comparison
+     * @return {Boolean} true if the date is the compared date; false
+     *     if not.
+     */
+    sameDay: function(date, compareTo) {
+        var ms = compareTo.getTime();
+        if (date.getTime() === ms) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    },
+
+    /**
      * Given a date, returns a {Date} object pointing to the last moment of the
      * day.
      *

--- a/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
@@ -170,6 +170,10 @@
     border: 1px solid #009be6 !important;
 }
 
+.scheduler-view-table-colgrid-today:not(.scheduler-view-table-grid-last) {
+    border-bottom-width: 0 !important;
+}
+
 .scheduler-view-table-data-col-title-today {
     color: #14a4e9;
     font-weight: bold;

--- a/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
@@ -167,8 +167,7 @@
 
 .scheduler-view-table-colgrid-today {
     background-color: #f2f2f2;
-    border: 1px solid #009be6;
-    border-bottom-width: 0;
+    border: 1px solid #009be6 !important;
 }
 
 .scheduler-view-table-data-col-title-today {

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -816,7 +816,9 @@ var SchedulerTableView = A.Component.create({
             var intervalStartDate = instance._findCurrentIntervalStart();
             var intervalEndDate = instance._findCurrentIntervalEnd();
 
-            if (DateMath.between(todayDate, intervalStartDate, intervalEndDate)) {
+            if (DateMath.between(todayDate, intervalStartDate, intervalEndDate) ||
+                DateMath.sameDay(todayDate, intervalStartDate)) {
+
                 var firstDayOfWeek = scheduler.get('firstDayOfWeek');
                 var firstWeekDay = instance._findFirstDayOfWeek(todayDate);
 

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -52,6 +52,7 @@ var Lang = A.Lang,
     CSS_SVT_TABLE_GRID = getCN('scheduler-view', 'table', 'grid'),
     CSS_SVT_TABLE_GRID_CONTAINER = getCN('scheduler-view', 'table', 'grid', 'container'),
     CSS_SVT_TABLE_GRID_FIRST = getCN('scheduler-view', 'table', 'grid', 'first'),
+    CSS_SVT_TABLE_GRID_LAST = getCN('scheduler-view', 'table', 'grid', 'last'),
 
     TPL_SVT_CONTAINER = '<div class="' + CSS_SVT_CONTAINER + '">' +
         '<div class="' + CSS_SVT_ROW_CONTAINER + '"></div>' +
@@ -819,6 +820,8 @@ var SchedulerTableView = A.Component.create({
                 var firstDayOfWeek = scheduler.get('firstDayOfWeek');
                 var firstWeekDay = instance._findFirstDayOfWeek(todayDate);
 
+                var weeksInMonth = DateMath.getWeeksInMonth(todayDate, firstDayOfWeek);
+
                 var rowIndex = DateMath.getWeekNumber(todayDate, firstDayOfWeek) - DateMath.getWeekNumber(
                     intervalStartDate, firstDayOfWeek);
                 var colIndex = (todayDate.getDate() - firstWeekDay.getDate());
@@ -828,6 +831,9 @@ var SchedulerTableView = A.Component.create({
 
                 if (todayCel) {
                     todayCel.addClass(CSS_SVT_COLGRID_TODAY);
+                    if (rowIndex === (weeksInMonth - 1)) {
+                        todayCel.addClass(CSS_SVT_TABLE_GRID_LAST);
+                    }
                 }
             }
         },

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -822,11 +822,20 @@ var SchedulerTableView = A.Component.create({
                 var firstDayOfWeek = scheduler.get('firstDayOfWeek');
                 var firstWeekDay = instance._findFirstDayOfWeek(todayDate);
 
+                var todayNumDate = todayDate.getDate();
+                var firstWeekNumDate = firstWeekDay.getDate();
+
                 var weeksInMonth = DateMath.getWeeksInMonth(todayDate, firstDayOfWeek);
 
                 var rowIndex = DateMath.getWeekNumber(todayDate, firstDayOfWeek) - DateMath.getWeekNumber(
                     intervalStartDate, firstDayOfWeek);
-                var colIndex = (todayDate.getDate() - firstWeekDay.getDate());
+                var colIndex = (todayNumDate - firstWeekNumDate);
+
+                if (firstWeekNumDate > todayNumDate) {
+                    colIndex = (DateMath.getDaysInMonth(
+                        firstWeekDay.getYear(), firstWeekDay.getMonth()) - firstWeekNumDate) + todayNumDate;
+                }
+
                 var celIndex = instance._getCellIndex([colIndex, rowIndex]);
 
                 var todayCel = instance.columnTableGrid.item(celIndex);


### PR DESCRIPTION
https://issues.liferay.com/browse/AUI-3178

The issue is the blue border that differentiates today's day is not properly displayed in the first week, the first day of each week, and the last week. 

The first week was not properly displayed because it did not account for the week displaying the previous month's last days. So originally, a negative value would be used as the column's index which returns a cell index that does not exist in the table. My fix would use a different expression to find the column index if the previous month's days are displayed in the current's month. I also created a [sameDay()](https://github.com/holatuwol/alloy-ui/commit/2625f449663c53a3b10a3509093fa1e47cbbdfac) because if today is the first day of the month and the intervalStartDay is the same day, the original implementation would return false. I have included the case that the days can be the same. 

The first day of each week was fixed by including the !important property. 

The last week had a problem with the bottom border of today's frame. This is because today's css selector included border-bottom-width: 0. My fix adds a new class selector to the last week of the month so that it can differentiate from the other weeks, thus the border-bottom-width would not be included. 