### PR TITLE
AUI-3178 In Calendar's monthly view, when today's date is the last week of the month, the blue border is cut out

### DIFF
--- a/src/aui-datatype/js/aui-datatype.js
+++ b/src/aui-datatype/js/aui-datatype.js
@@ -944,6 +944,39 @@ A.mix(A.DataType.DateMath, {
     },
 
     /**
+     * Gets number of weeks from a given date and first day of the week.
+     *
+     * @method getWeeksInMonth
+     * @param date
+     * @param firstDayOfWeek
+     * @return {Number}
+     */
+    getWeeksInMonth: function(date, firstDayOfWeek) {
+        var daysInMonth = this.getDaysInMonth(
+            date.getFullYear(),
+            date.getMonth()
+        );
+        var firstWeekDay =
+            this.getDate(
+                date.getFullYear(),
+                date.getMonth(),
+                1
+            ).getDay() - firstDayOfWeek;
+
+        if (firstWeekDay < 0) {
+            firstWeekDay = firstWeekDay + 7;
+        }
+
+        var daysInFirstWeek = this.WEEK_LENGTH - firstWeekDay;
+
+        return (
+            Math.ceil(
+                (daysInMonth - daysInFirstWeek) / this.WEEK_LENGTH
+            ) + 1
+        );
+    },
+
+    /**
      * Converts a date to US time format.
      *
      * @method toUsTimeString

--- a/src/aui-datatype/js/aui-datatype.js
+++ b/src/aui-datatype/js/aui-datatype.js
@@ -457,6 +457,26 @@ A.mix(A.DataType.DateMath, {
     },
 
     /**
+     * Determines whether a given date is the same date on the calendar.
+     *
+     * @method sameDay
+     * @param {Date} date The Date object to compare with the compare
+     *     argument
+     * @param {Date} compareTo The Date object to use for the comparison
+     * @return {Boolean} true if the date is the compared date; false
+     *     if not.
+     */
+    sameDay: function(date, compareTo) {
+        var ms = compareTo.getTime();
+        if (date.getTime() === ms) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    },
+
+    /**
      * Determines whether a given date is between two other dates on the
      * calendar.
      *

--- a/src/aui-form-validator/HISTORY.md
+++ b/src/aui-form-validator/HISTORY.md
@@ -12,6 +12,7 @@
 
 ## [3.1.0](https://github.com/liferay/alloy-ui/releases/tag/3.1.0)
 
+* [AUI-3173](https://issues.liferay.com/browse/AUI-3173) Add delay for required validation fields error message display
 * [AUI-2811](https://issues.liferay.com/browse/AUI-2811) IE8 showing error "Object doesn't support this property or method" for aui-form-validator.js file
 * [AUI-2094](https://issues.liferay.com/browse/AUI-2094) Remove feedback added by Form Validator when the field is not required and empty
 * [AUI-2055](https://issues.liferay.com/browse/AUI-2055) aria-invalid attribute not removed from blank input fields

--- a/src/aui-form-validator/HISTORY.md
+++ b/src/aui-form-validator/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-3173](https://issues.liferay.com/browse/AUI-3173) Add delay for required validation fields error message display
 * [AUI-3174](https://issues.liferay.com/browse/AUI-3174) Move target field to parent node to guarantee that we will be targeting a visible node for a given field
 * [AUI-3168](https://issues.liferay.com/browse/AUI-3168) Ensure Validator Reset only applies to fields with rules
 * [AUI-3153](https://issues.liferay.com/browse/AUI-3153) Validation Firing When Attempting to Follow the Cancel Link from an AUI Form
@@ -12,7 +13,6 @@
 
 ## [3.1.0](https://github.com/liferay/alloy-ui/releases/tag/3.1.0)
 
-* [AUI-3173](https://issues.liferay.com/browse/AUI-3173) Add delay for required validation fields error message display
 * [AUI-2811](https://issues.liferay.com/browse/AUI-2811) IE8 showing error "Object doesn't support this property or method" for aui-form-validator.js file
 * [AUI-2094](https://issues.liferay.com/browse/AUI-2094) Remove feedback added by Form Validator when the field is not required and empty
 * [AUI-2055](https://issues.liferay.com/browse/AUI-2055) aria-invalid attribute not removed from blank input fields

--- a/src/aui-form-validator/js/aui-form-validator.js
+++ b/src/aui-form-validator/js/aui-form-validator.js
@@ -1326,9 +1326,12 @@ var FormValidator = A.Component.create({
             var skipValidationTargetSelector = instance.get('skipValidationTargetSelector');
 
             if (!event.relatedTarget || !event.relatedTarget.getDOMNode().matches(skipValidationTargetSelector)) {
-                setTimeout(function() {
-                    instance.validateField(event.target);
-                }, 300);
+                setTimeout(
+                    function() {
+                        instance.validateField(event.target);
+                    },
+                    300
+                );
             }
         },
 

--- a/src/aui-form-validator/js/aui-form-validator.js
+++ b/src/aui-form-validator/js/aui-form-validator.js
@@ -1326,7 +1326,9 @@ var FormValidator = A.Component.create({
             var skipValidationTargetSelector = instance.get('skipValidationTargetSelector');
 
             if (!event.relatedTarget || !event.relatedTarget.getDOMNode().matches(skipValidationTargetSelector)) {
-                instance.validateField(event.target);
+                setTimeout(function() {
+                    instance.validateField(event.target);
+                }, 300);
             }
         },
 

--- a/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
@@ -171,6 +171,10 @@
     border-bottom-width: 0;
 }
 
+.scheduler-view-table-row:last-child .scheduler-view-table-colgrid-today {
+    border-bottom-width: 1px;
+}
+
 .scheduler-view-table-data-col-title-today {
     color: #14a4e9;
     font-weight: bold;

--- a/src/aui-scheduler/js/aui-scheduler-view-month.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-month.js
@@ -176,6 +176,30 @@ var SchedulerMonthView = A.Component.create({
         },
 
         /**
+         * Returns the current interval end by finding the number of weeks
+         * with the `Scheduler`'s `todayDate` and `firstDayOfWeek` and calculating
+         * the number of days to display in the current month.
+         *
+         * @method _findCurrentIntervalEnd
+         * @protected
+         * @return {Date} The current interval end from the amount of days in the
+         * in the month's view added to the 'startDate' of the calendar month.
+         */
+        _findCurrentIntervalEnd: function() {
+            var instance = this;
+            var scheduler = instance.get('scheduler');
+            var todayDate = scheduler.get('todayDate');
+            var firstDayOfWeek = scheduler.get('firstDayOfWeek');
+
+            var weeks = DateMath.getWeeksInMonth(todayDate, firstDayOfWeek);
+
+            var daysAmount = instance.getWeekDaysCount() * weeks - 1;
+            var startDate = instance._findCurrentIntervalStart();
+
+            return DateMath.add(startDate, DateMath.DAY, daysAmount);
+        },
+
+        /**
          * Returns the current interval start by finding the first day of the
          * week with the `Scheduler`'s `viewDate`.
          *

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -812,16 +812,16 @@ var SchedulerTableView = A.Component.create({
 
             instance.columnTableGrid.removeClass(CSS_SVT_COLGRID_TODAY);
 
-            var intervalStartDate = instance._findCurrentIntervalStart();
-            var intervalEndDate = instance._findCurrentIntervalEnd();
+            var interval = instance.getDateInterval();
 
-            if (DateMath.between(todayDate, intervalStartDate, intervalEndDate)) {
+            if (DateMath.between(todayDate, interval.startDate, interval.endDate)) {
                 var firstDayOfWeek = scheduler.get('firstDayOfWeek');
                 var firstWeekDay = instance._findFirstDayOfWeek(todayDate);
 
                 var rowIndex = DateMath.getWeekNumber(todayDate, firstDayOfWeek) - DateMath.getWeekNumber(
-                    intervalStartDate, firstDayOfWeek);
-                var colIndex = (todayDate.getDate() - firstWeekDay.getDate());
+                    interval.startDate, firstDayOfWeek);
+                var colIndex = (todayDate.getDay() - firstWeekDay.getDay() + WEEK_LENGTH) % WEEK_LENGTH;
+
                 var celIndex = instance._getCellIndex([colIndex, rowIndex]);
 
                 var todayCel = instance.columnTableGrid.item(celIndex);

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -814,7 +814,9 @@ var SchedulerTableView = A.Component.create({
 
             var interval = instance.getDateInterval();
 
-            if (DateMath.between(todayDate, interval.startDate, interval.endDate)) {
+            if (DateMath.between(todayDate, interval.startDate, interval.endDate) ||
+                DateMath.sameDay(todayDate, interval.startDate)) {
+
                 var firstDayOfWeek = scheduler.get('firstDayOfWeek');
                 var firstWeekDay = instance._findFirstDayOfWeek(todayDate);
 

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -625,11 +625,11 @@ var SchedulerTableView = A.Component.create({
          *   keys are interpreted as unlimited sides of the interval.
          */
         getDateInterval: function() {
-            var daysAmount = this.getWeekDaysCount() * this._getDisplayRowsCount() - 1,
-                startDate = this._findCurrentIntervalStart();
+            var startDate = this._findCurrentIntervalStart(),
+                endDate = this._findCurrentIntervalEnd();
 
             return {
-                endDate: DateMath.toLastHour(DateMath.add(startDate, DateMath.DAY, daysAmount)),
+                endDate: DateMath.toLastHour(endDate),
                 startDate: DateMath.toMidnight(startDate)
             };
         },


### PR DESCRIPTION
https://issues.liferay.com/browse/AUI-3178

Liferay interval is using the default number of days per interval, which works for demo because demo is using the defaults in their Calendar view whereas Liferay is hidding irrelevant weeks that do not pertain to the current month.

https://github.com/holatuwol/alloy-ui/pull/2/commits/c2855460e5afe202f971df09a9b2b030d4d9dbe8: Interval is not aligned with the Calendar's view. The default number of days to display per interval is currently 42. This commit includes a check if the Calendar view has hidden a week, if so, it would change the number of days to display in that interval. It would return a new value for [daysAmount](https://github.com/holatuwol/alloy-ui/pull/2/files#diff-f55252c03ae51441ce1bf0a64c008252R634).

https://github.com/holatuwol/alloy-ui/commit/3e19f93acdd837cb7903ab3c62c6734e54115e8f: Checks for when the first day of the month is the start day of the month and when the start of the week is from the previous month. This fixes when today's date is the first day of the month. 