### PR TITLE
AUI-3178 In Calendar's monthly view, when today's date is the last week of the month, the blue border is cut out

### DIFF
--- a/src/aui-datatype/js/aui-datatype.js
+++ b/src/aui-datatype/js/aui-datatype.js
@@ -477,6 +477,26 @@ A.mix(A.DataType.DateMath, {
     },
 
     /**
+     * Determines whether a given date is inclusively between two other
+     * dates on the calendar.
+     *
+     * @method betweenInclusive
+     * @param {Date} date The date to check for
+     * @param {Date} dateBegin The start of the range
+     * @param {Date} dateEnd The end of the range
+     * @return {Boolean} true if the date occurs between the dates
+     * (including the two dates); false if not.
+     */
+    betweenInclusive: function(date, dateBegin, dateEnd) {
+        if (this.between(date, dateBegin, dateEnd) || this.compare(date, dateBegin) || this.compare(date, dateEnd)) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    },
+
+    /**
      * Retrieves a JavaScript Date object representing January 1 of any given
      * year.
      *

--- a/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
@@ -171,6 +171,10 @@
     border-bottom-width: 0;
 }
 
+.scheduler-view-table-row:last-child .scheduler-view-table-colgrid-today {
+    border-bottom-width: 1px;
+}
+
 .scheduler-view-table-data-col-title-today {
     color: #14a4e9;
     font-weight: bold;

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -812,16 +812,16 @@ var SchedulerTableView = A.Component.create({
 
             instance.columnTableGrid.removeClass(CSS_SVT_COLGRID_TODAY);
 
-            var intervalStartDate = instance._findCurrentIntervalStart();
-            var intervalEndDate = instance._findCurrentIntervalEnd();
+            var interval = instance.getDateInterval();
 
-            if (DateMath.between(todayDate, intervalStartDate, intervalEndDate)) {
+            if (DateMath.between(todayDate, interval.startDate, interval.endDate)) {
                 var firstDayOfWeek = scheduler.get('firstDayOfWeek');
                 var firstWeekDay = instance._findFirstDayOfWeek(todayDate);
 
                 var rowIndex = DateMath.getWeekNumber(todayDate, firstDayOfWeek) - DateMath.getWeekNumber(
-                    intervalStartDate, firstDayOfWeek);
-                var colIndex = (todayDate.getDate() - firstWeekDay.getDate());
+                    interval.startDate, firstDayOfWeek);
+                var colIndex = (todayDate.getDay() - firstWeekDay.getDay() + WEEK_LENGTH) % WEEK_LENGTH;
+
                 var celIndex = instance._getCellIndex([colIndex, rowIndex]);
 
                 var todayCel = instance.columnTableGrid.item(celIndex);

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -814,7 +814,7 @@ var SchedulerTableView = A.Component.create({
 
             var interval = instance.getDateInterval();
 
-            if (DateMath.between(todayDate, interval.startDate, interval.endDate)) {
+            if (DateMath.betweenInclusive(todayDate, interval.startDate, interval.endDate)) {
                 var firstDayOfWeek = scheduler.get('firstDayOfWeek');
                 var firstWeekDay = instance._findFirstDayOfWeek(todayDate);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/AUI-3178

LPS Issue: https://issues.liferay.com/browse/LPS-102368

https://github.com/holatuwol/alloy-ui/commit/9f83d06426ae1f391a3e37faaf7de4f107666371 fixes edge case when today's date is the first cell of the month. 